### PR TITLE
[HB-4463] Fixed banners and a few changes for AppLovin interstitials

### DIFF
--- a/AppLovinAdapter/src/main/java/com/chartboost/helium/applovinadapter/AppLovinAdapter.kt
+++ b/AppLovinAdapter/src/main/java/com/chartboost/helium/applovinadapter/AppLovinAdapter.kt
@@ -297,7 +297,6 @@ class AppLovinAdapter : PartnerAdapter {
         partnerAdListener: PartnerAdListener
     ): Result<PartnerAd> {
         return suspendCoroutine { continuation ->
-            // Create the AppLovin AdView
             AppLovinAdView(
                 getAppLovinAdSize(request.size),
                 request.partnerPlacement,


### PR DESCRIPTION
## Context
While investigating our adapters for all networks, I came across AppLovin no longer being able to display banners and interstitials.

## Changes
- Fixed Banners as they need to be done on the main thread.
- Fixed Interstitials as it was using helium placement instead of partner placement.
