### PR TITLE
AppLovin 4.11.11.2.3

### DIFF
--- a/AppLovinAdapter/build.gradle.kts
+++ b/AppLovinAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.11.11.2.2"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.11.11.2.3"
         buildConfigField("String", "CHARTBOOST_MEDIATION_APPLOVIN_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
+++ b/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
@@ -34,11 +34,6 @@ import kotlin.coroutines.resume
 class AppLovinAdapter : PartnerAdapter {
     companion object {
         /**
-         * The AppLovin SDK needs an instance that is later passed to its ad lifecycle methods.
-         */
-        private var appLovinSdk: AppLovinSdk? = null
-
-        /**
          * Enable/disable AppLovin's test mode. Remember to set this to false in production.
          *
          * @param context The current [Context].
@@ -107,10 +102,9 @@ class AppLovinAdapter : PartnerAdapter {
         /**
          * Enable/disable AppLovin's mute setting.
          *
-         * @param context The current [Context].
          * @param muted True to mute, false otherwise.
          */
-        public fun setMuted(context: Context, muted: Boolean) {
+        public fun setMuted(muted: Boolean) {
             appLovinSdk?.let { sdk ->
                 sdk.settings.isMuted = muted
 
@@ -127,10 +121,9 @@ class AppLovinAdapter : PartnerAdapter {
         /**
          * Enable/disable AppLovin's verbose logging.
          *
-         * @param context The current [Context].
          * @param enabled True to enable verbose logging, false otherwise.
          */
-        public fun setVerboseLogging(context: Context, enabled: Boolean) {
+        public fun setVerboseLogging(enabled: Boolean) {
             appLovinSdk?.let { sdk ->
                 sdk.settings.setVerboseLogging(enabled)
 
@@ -162,6 +155,11 @@ class AppLovinAdapter : PartnerAdapter {
                 "Unable to set location sharing. AppLovin SDK instance is null."
             )
         }
+
+        /**
+         * The AppLovin SDK needs an instance that is later passed to its ad lifecycle methods.
+         */
+        private var appLovinSdk: AppLovinSdk? = null
     }
 
     /**

--- a/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
+++ b/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
@@ -34,6 +34,11 @@ import kotlin.coroutines.resume
 class AppLovinAdapter : PartnerAdapter {
     companion object {
         /**
+         * The AppLovin SDK needs an instance that is later passed to its ad lifecycle methods.
+         */
+        private var appLovinSdk: AppLovinSdk? = null
+
+        /**
          * Enable/disable AppLovin's test mode. Remember to set this to false in production.
          *
          * @param context The current [Context].
@@ -52,29 +57,51 @@ class AppLovinAdapter : PartnerAdapter {
 
                     adInfo?.let { adId ->
                         withContext(Main) {
-                            AppLovinSdk.getInstance(context).settings.testDeviceAdvertisingIds =
-                                listOf(adId)
+                            appLovinSdk?.let { sdk ->
+                                sdk.settings?.testDeviceAdvertisingIds = listOf(adId)
+
+                                PartnerLogController.log(
+                                    CUSTOM,
+                                    "AppLovin test mode is enabled. Remember to disable it before publishing."
+                                )
+                            } ?: run {
+                                PartnerLogController.log(
+                                    CUSTOM,
+                                    "Unable to set test mode. AppLovin SDK instance is null."
+                                )
+                            }
                         }
                     } ?: run {
-                        PartnerLogController.log(
-                            CUSTOM,
-                            "AppLovin test mode is disabled. No advertising id found."
-                        )
-                        AppLovinSdk.getInstance(context).settings.testDeviceAdvertisingIds =
-                            emptyList()
+                        appLovinSdk?.let { sdk ->
+                            sdk.settings?.testDeviceAdvertisingIds = emptyList()
+
+                            PartnerLogController.log(
+                                CUSTOM,
+                                "AppLovin test mode is disabled. No advertising id found."
+                            )
+                        } ?: run {
+                            PartnerLogController.log(
+                                CUSTOM,
+                                "Unable to set test mode. AppLovin SDK instance is null."
+                            )
+                        }
                     }
                 }
             } else {
-                AppLovinSdk.getInstance(context).settings.testDeviceAdvertisingIds = emptyList()
-            }
+                appLovinSdk?.let { sdk ->
+                    sdk.settings?.testDeviceAdvertisingIds = emptyList()
 
-            PartnerLogController.log(
-                CUSTOM,
-                "AppLovin test mode is ${
-                    if (enabled) "enabled. Remember to disable it before publishing."
-                    else "disabled."
-                }"
-            )
+                    PartnerLogController.log(
+                        CUSTOM,
+                        "AppLovin test mode is disabled."
+                    )
+                } ?: run {
+                    PartnerLogController.log(
+                        CUSTOM,
+                        "Unable to set test mode. AppLovin SDK instance is null."
+                    )
+                }
+            }
         }
 
         /**
@@ -84,10 +111,16 @@ class AppLovinAdapter : PartnerAdapter {
          * @param muted True to mute, false otherwise.
          */
         public fun setMuted(context: Context, muted: Boolean) {
-            AppLovinSdk.getInstance(context).settings.isMuted = muted
-            PartnerLogController.log(
+            appLovinSdk?.let { sdk ->
+                sdk.settings.isMuted = muted
+
+                PartnerLogController.log(
+                    CUSTOM,
+                    "AppLovin video creatives will be ${if (muted) "muted" else "unmuted"}."
+                )
+            } ?: PartnerLogController.log(
                 CUSTOM,
-                "AppLovin video creatives will be ${if (muted) "muted" else "unmuted"}."
+                "Unable to set muted. AppLovin SDK instance is null."
             )
         }
 
@@ -98,33 +131,38 @@ class AppLovinAdapter : PartnerAdapter {
          * @param enabled True to enable verbose logging, false otherwise.
          */
         public fun setVerboseLogging(context: Context, enabled: Boolean) {
-            AppLovinSdk.getInstance(context).settings.setVerboseLogging(enabled)
-            PartnerLogController.log(
+            appLovinSdk?.let { sdk ->
+                sdk.settings.setVerboseLogging(enabled)
+
+                PartnerLogController.log(
+                    CUSTOM,
+                    "AppLovin verbose logging is ${if (enabled) "enabled" else "disabled"}."
+                )
+            } ?: PartnerLogController.log(
                 CUSTOM,
-                "AppLovin verbose logging is ${if (enabled) "enabled" else "disabled"}."
+                "Unable to set verbose logging. AppLovin SDK instance is null."
             )
         }
 
         /**
          * Enable/disable AppLovin's location sharing.
          *
-         * @param context The current [Context].
          * @param enabled True to enable location sharing, false otherwise.
          */
-        public fun setLocationSharing(context: Context, enabled: Boolean) {
-            AppLovinSdk.getInstance(context).settings.isLocationCollectionEnabled = enabled
+        fun setLocationSharing(enabled: Boolean) {
+            appLovinSdk?.let { sdk ->
+                sdk.settings.isLocationCollectionEnabled = enabled
 
-            PartnerLogController.log(
+                PartnerLogController.log(
+                    CUSTOM,
+                    "AppLovin location sharing is ${if (enabled) "enabled" else "disabled"}."
+                )
+            } ?: PartnerLogController.log(
                 CUSTOM,
-                "AppLovin location sharing is ${if (enabled) "enabled" else "disabled"}."
+                "Unable to set location sharing. AppLovin SDK instance is null."
             )
         }
     }
-
-    /**
-     * The AppLovin SDK needs an instance that is later passed to its ad lifecycle methods.
-     */
-    private var appLovinSdk: AppLovinSdk? = null
 
     /**
      * The AppLovin SDK needs a context for its privacy methods.

--- a/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
+++ b/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
@@ -53,7 +53,7 @@ class AppLovinAdapter : PartnerAdapter {
                     adInfo?.let { adId ->
                         withContext(Main) {
                             appLovinSdk?.let { sdk ->
-                                sdk.settings?.testDeviceAdvertisingIds = listOf(adId)
+                                sdk.settings.testDeviceAdvertisingIds = listOf(adId)
 
                                 PartnerLogController.log(
                                     CUSTOM,
@@ -68,7 +68,7 @@ class AppLovinAdapter : PartnerAdapter {
                         }
                     } ?: run {
                         appLovinSdk?.let { sdk ->
-                            sdk.settings?.testDeviceAdvertisingIds = emptyList()
+                            sdk.settings.testDeviceAdvertisingIds = emptyList()
 
                             PartnerLogController.log(
                                 CUSTOM,
@@ -84,7 +84,7 @@ class AppLovinAdapter : PartnerAdapter {
                 }
             } else {
                 appLovinSdk?.let { sdk ->
-                    sdk.settings?.testDeviceAdvertisingIds = emptyList()
+                    sdk.settings.testDeviceAdvertisingIds = emptyList()
 
                     PartnerLogController.log(
                         CUSTOM,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.11.11.2.3
+- Fix adapter logic pertaining to setting test mode, mute state, verbose logging, and location sharing.
+
 ### 4.11.11.2.2
 - Updated to handle recent AdFormat changes.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation AppLovin adapter mediates AppLovin via the Chartboost M
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-applovin:4.11.11.2.2"
+    implementation "com.chartboost:chartboost-mediation-adapter-applovin:4.11.11.2.3"
 ```
 
 ## Contributions


### PR DESCRIPTION
Context: https://zng-commons.slack.com/archives/C041VM54C3U/p1695391687290069.

Essentially making the AppLovin SDK instance static in order to be reused by the settings setters.