### PR TITLE
[HB-7187] Update AppLovin adapter to perform `setUp` on `IO` instead of `Main`

### DIFF
--- a/AppLovinAdapter/build.gradle.kts
+++ b/AppLovinAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.12.1.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.12.1.0.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_APPLOVIN_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
+++ b/AppLovinAdapter/src/main/java/com/chartboost/mediation/applovinadapter/AppLovinAdapter.kt
@@ -695,8 +695,8 @@ class AppLovinAdapter : PartnerAdapter {
         context: Context,
         partnerAd: PartnerAd,
         partnerAdListener: PartnerAdListener?,
-    ): Result<PartnerAd> {
-        return suspendCancellableCoroutine { continuation ->
+    ): Result<PartnerAd> = withContext(IO) {
+        return@withContext suspendCancellableCoroutine { continuation ->
             val rewardedAd = AppLovinIncentivizedInterstitial.create(appLovinSdk)
 
             var isUserVerified: Boolean? = null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.12.1.0.1
+- This version of the adapter has been certified with AppLovin SDK 12.1.0 and performs initialization on `IO` to help reduce potential ANR issues.
+
 ### 4.12.1.0.0
 - This version of the adapter has been certified with AppLovin SDK 12.1.0.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation AppLovin adapter mediates AppLovin via the Chartboost M
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-applovin:4.12.1.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-applovin:4.12.1.0.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
To reduce the potential of ANRs, the adapter setUp method has been changed to be perform the work on the IO coroutine context.